### PR TITLE
Fix datalog summary display

### DIFF
--- a/frontend/src/components/AnalysisViewer.jsx
+++ b/frontend/src/components/AnalysisViewer.jsx
@@ -26,14 +26,28 @@ function AnalysisViewer({ data }) {
     // Create datalog summary from available data
     const summary = datalogAnalysis.summary || {};
     const datalog_summary = {
-
-        total_rows: summary.total_rows || summary.total_records || datalogAnalysis.total_records || data.total_rows || 0,
-
-        total_rows: summary.total_records || datalogAnalysis.total_records || data.total_rows || 0,
-
-        total_columns: summary.total_columns || datalogAnalysis.parameters_analyzed || data.total_columns || 0,
-        duration: summary.duration || datalogAnalysis.duration_seconds || data.duration || 0,
-        issues_found: datalogAnalysis.issues_found || summary.issues_found || issues.length || 0
+        // Number of rows/records in the datalog
+        total_rows: summary.total_rows ||
+            summary.total_records ||
+            datalogAnalysis.total_rows ||
+            datalogAnalysis.total_records ||
+            data.total_rows ||
+            0,
+        // Number of parameters/columns logged
+        total_columns: summary.total_columns ||
+            datalogAnalysis.parameters_analyzed ||
+            data.total_columns ||
+            0,
+        // Duration of the log in seconds
+        duration: summary.duration ||
+            datalogAnalysis.duration_seconds ||
+            data.duration ||
+            0,
+        // How many issues were detected
+        issues_found: datalogAnalysis.issues_found ||
+            summary.issues_found ||
+            issues.length ||
+            0,
     };
 
     const renderIssues = () => {


### PR DESCRIPTION
## Summary
- correct `datalog_summary` calculation in `AnalysisViewer`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f3e91f388326b3a70b3494759914