### PR TITLE
Improve lean AFR suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,21 @@ npm install
 
 ### FastAPI server
 
-Run the backend API with Uvicorn:
+Before starting the server, install the backend requirements:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+Then run the API with Uvicorn:
 
 ```bash
 uvicorn backend.main:app --reload
 ```
 
 This starts the API at <http://localhost:8000>.
+Set the `JWT_SECRET` environment variable to the shared secret used for verifying
+JWT bearer tokens.
 
 ### React app
 
@@ -47,7 +55,6 @@ The development server will open at <http://localhost:3000> and proxy API reques
 
 ### Backend tests
 
-Install the backend dependencies and then run unit tests:
 Install the backend dependencies and run unit tests with:
 
 

--- a/backend/ai_suggestions.py
+++ b/backend/ai_suggestions.py
@@ -60,6 +60,22 @@ def generate_suggestions(analysis_data: Dict[str, Any]) -> List[Dict[str, Any]]:
         avg_afr = afr_values.mean()
 
         if lean_count > 0:
+            # Determine typical load (psia) and RPM for lean events
+            psia = None
+            rpm = None
+            psia_range = None
+            rpm_range = None
+            if "Manifold Absolute Pressure (psi)" in df.columns:
+                lean_psia = df.loc[afr_values > 15.0, "Manifold Absolute Pressure (psi)"].dropna()
+                psia = lean_psia.mean()
+                if not lean_psia.empty:
+                    psia_range = [float(lean_psia.min()), float(lean_psia.max())]
+            if "Engine Speed (rpm)" in df.columns:
+                lean_rpm = df.loc[afr_values > 15.0, "Engine Speed (rpm)"].dropna()
+                rpm = lean_rpm.mean()
+                if not lean_rpm.empty:
+                    rpm_range = [int(lean_rpm.min()), int(lean_rpm.max())]
+
             suggestions.append({
                 "id": "afr_lean_condition",
                 "type": "Fuel Enrichment",
@@ -68,6 +84,13 @@ def generate_suggestions(analysis_data: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "parameter": "fuel_map",
                 "change_type": "increase",
                 "percentage": 8,
+                "psia": round(float(psia), 1) if psia is not None else None,
+                "rpm": int(round(float(rpm))) if rpm is not None else None,
+                "tuning_cells": {
+                    "psia_range": [round(psia_range[0], 1), round(psia_range[1], 1)] if psia_range else None,
+                    "rpm_range": rpm_range,
+                },
+                "tuning_strategy": "weighted_average_4x4",
                 "affected_areas": "Lean AFR regions",
                 "safety_impact": "Critical - prevents engine damage from lean conditions",
                 "performance_impact": "Safer operation, prevents detonation"

--- a/backend/main.py
+++ b/backend/main.py
@@ -106,9 +106,24 @@ def to_python_types(obj):
         return obj
 
 
+from jose import jwt, JWTError
+
+JWT_ALGORITHM = "HS256"
+JWT_SECRET = os.getenv("JWT_SECRET", "demo_secret")
+
+
 def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    # TODO: Implement real JWT verification
-    return {"user_id": "demo_user", "role": "user"}
+    """Validate JWT bearer token and return user information."""
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        user_id = payload.get("sub")
+        role = payload.get("role", "user")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return {"user_id": user_id, "role": role}
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
 
 
 def is_admin(user: dict = Depends(verify_token)):

--- a/frontend/src/components/TuneDiffViewer.jsx
+++ b/frontend/src/components/TuneDiffViewer.jsx
@@ -147,9 +147,9 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
                                 <span className="change-parameter">{change.parameter}</span>
                                 <span
                                     className="impact-badge"
-                                    style={{ backgroundColor: getImpactColor(change.impact) }}
+                                    style={{ backgroundColor: getImpactColor(change?.impact || change?.priority) }}
                                 >
-                                    {change.impact.toUpperCase()}
+                                    {(change?.impact || change?.priority || 'medium').toUpperCase()}
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- give more context when AFR readings are lean
- indicate psia, rpm and strategy used for tuning suggestions
- expose cell ranges for tuning
- implement JWT validation and remove runtime crash
- add test instructions
- handle missing priority in diff viewer
- clarify installation before starting server

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640afb53e08326bd52f0e3545941a9