### PR TITLE
Add option to disable JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ uvicorn backend.main:app --reload
 
 This starts the API at <http://localhost:8000>.
 Set the `JWT_SECRET` environment variable to the shared secret used for verifying
-JWT bearer tokens.
+JWT bearer tokens. During development you can bypass authentication entirely by
+setting `DISABLE_JWT_AUTH=1` when launching the server.
 
 ### React app
 


### PR DESCRIPTION
## Summary
- allow `HTTPBearer` to accept missing token
- add `DISABLE_JWT_AUTH` env option and return dev user when enabled
- document JWT disable flag in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647cb7d62483268a8eace70aff6336