### PR TITLE
Improve JWT disable docs and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ Set the `JWT_SECRET` environment variable to the shared secret used for verifyin
 JWT bearer tokens. During development you can bypass authentication entirely by
 setting `DISABLE_JWT_AUTH=1` when launching the server.
 
+Example (Linux/macOS shell):
+
+```bash
+export DISABLE_JWT_AUTH=1
+uvicorn backend.main:app --reload
+```
+
+Example (Windows PowerShell):
+
+```powershell
+$Env:DISABLE_JWT_AUTH=1
+uvicorn backend.main:app --reload
+```
+
 ### React app
 
 From the `frontend` folder execute:

--- a/backend/main.py
+++ b/backend/main.py
@@ -112,6 +112,7 @@ from jose import jwt, JWTError
 JWT_ALGORITHM = "HS256"
 JWT_SECRET = os.getenv("JWT_SECRET", "demo_secret")
 DISABLE_JWT_AUTH = os.getenv("DISABLE_JWT_AUTH", "0") == "1"
+logger.info("JWT auth disabled: %s", DISABLE_JWT_AUTH)
 
 
 def verify_token(credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)):


### PR DESCRIPTION
## Summary
- show how to disable JWT auth in different shells
- log whether JWT auth is disabled when the backend starts

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686484e705888326a22e8a2e362716cc