### PR TITLE
Fix missing Optional import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, UploadFile, File, Body, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from typing import Dict, List
+from typing import Dict, List, Optional
 from datetime import datetime, timezone
 import os
 import json


### PR DESCRIPTION
## Summary
- fix missing Optional import in backend

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864940208cc83269daa0543cd1a4c60