### PR TITLE
Display analysis report

### DIFF
--- a/frontend/src/components/AnalysisReport.css
+++ b/frontend/src/components/AnalysisReport.css
@@ -1,0 +1,41 @@
+.analysis-report {
+    background: #f8f9fa;
+    border-radius: 10px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.analysis-report h3 {
+    color: #333;
+    margin-bottom: 1rem;
+}
+
+.metadata-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.metadata-item {
+    background: white;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.meta-label {
+    display: block;
+    color: #666;
+    font-size: 0.85rem;
+    margin-bottom: 0.25rem;
+}
+
+.meta-value {
+    font-weight: bold;
+    font-size: 1rem;
+}
+
+.rom-compatibility {
+    margin-top: 1rem;
+}

--- a/frontend/src/components/AnalysisReport.jsx
+++ b/frontend/src/components/AnalysisReport.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import './AnalysisReport.css';
+
+function formatLabel(key) {
+    return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function AnalysisReport({ metadata, romCompatibility }) {
+    if (!metadata) return null;
+
+    return (
+        <div className="analysis-report">
+            <h3>Analysis Report</h3>
+            <div className="metadata-grid">
+                {Object.entries(metadata).map(([key, value]) => (
+                    <div key={key} className="metadata-item">
+                        <span className="meta-label">{formatLabel(key)}</span>
+                        <span className="meta-value">{String(value)}</span>
+                    </div>
+                ))}
+            </div>
+            {romCompatibility && (
+                <div className="rom-compatibility">
+                    <h4>ROM Compatibility</h4>
+                    <pre>{JSON.stringify(romCompatibility, null, 2)}</pre>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default AnalysisReport;

--- a/frontend/src/components/TuneDiffViewer.jsx
+++ b/frontend/src/components/TuneDiffViewer.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './TuneDiffViewer.css';
 import CarberryTableDiff from './CarberryTableDiff';
+import AnalysisReport from './AnalysisReport';
 
 function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
     const [diffData, setDiffData] = useState(null);
@@ -36,12 +37,19 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
                 const detailed = data.detailed_changes || data.changes || [];
                 const summary = {
                     totalChanges: data.total_changes || detailed.length,
-                    highImpactChanges: detailed.filter(c => (c.priority || '').toLowerCase() === 'high' || (c.priority || '').toLowerCase() === 'critical').length,
+                    highImpactChanges: detailed.filter(
+                        (c) => (c.priority || '').toLowerCase() === 'high' || (c.priority || '').toLowerCase() === 'critical'
+                    ).length,
                     estimatedPowerChange: data.estimated_power_gain || 'N/A',
                     safetyRating: data.safety_rating || 'Unknown'
                 };
 
-                setDiffData({ changes: detailed, summary });
+                setDiffData({
+                    changes: detailed,
+                    summary,
+                    analysisMetadata: data.analysis_metadata,
+                    romCompatibility: data.rom_compatibility
+                });
             } else {
                 setDiffData({ changes: [], summary: {} });
             }
@@ -188,6 +196,13 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
                     <h3>Table Preview</h3>
                     <CarberryTableDiff diff={tableDiff} />
                 </div>
+            )}
+
+            {diffData.analysisMetadata && (
+                <AnalysisReport
+                    metadata={diffData.analysisMetadata}
+                    romCompatibility={diffData.romCompatibility}
+                />
             )}
 
             <div className="diff-actions">


### PR DESCRIPTION
## Summary
- add AnalysisReport component to show metadata
- show analysis report in TuneDiffViewer with ROM compatibility

## Testing
- `pytest -q`
- `npm test -- -w 0`

------
https://chatgpt.com/codex/tasks/task_e_686498a15ef48326914c1569f2b50bdb