### PR TITLE
Improve diff viewer hook and add verification guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ The application coordinates several specialized agents:
 - **supervisor** – oversees all agents, delegating tasks and enforcing standards.
 
 These agents collaborate through documented APIs and follow strict safety and accessibility requirements.
+
+## Data Verification
+
+See `docs/data_validation.md` for a checklist of metadata and change details exposed by the platform. Each API response includes enough information for tuners to cross-check ROM metadata, table differences and safety metrics before applying suggestions.

--- a/docs/data_validation.md
+++ b/docs/data_validation.md
@@ -1,0 +1,14 @@
+# Tuning Data Verification Guide
+
+This guide outlines the key data points exposed by the application so that tuners can verify and validate every recommendation. It was prepared with advice from the `tuning-ai` expert agent.
+
+## What the User Should See
+
+- **ROM Metadata** – file name, size, checksum and parser version.
+- **Analysis Metadata** – timestamps, tables parsed, issues count and safety status for traceability.
+- **Detailed Tune Changes** – each change lists the parameter, new and old value range, affected cells and estimated impact.
+- **Table Previews** – before/after values for ROM tables to cross-check with the original tune.
+- **Compatibility Information** – ROM compatibility metrics and any warnings about unsupported tables.
+- **Raw Exports** – downloadable JSON or CSV files containing all computed changes for offline review.
+
+Consult this document when building UI components to ensure end users can inspect every value used by the AI recommendation engine.

--- a/frontend/src/components/TuneDiffViewer.jsx
+++ b/frontend/src/components/TuneDiffViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import './TuneDiffViewer.css';
 import CarberryTableDiff from './CarberryTableDiff';
 import AnalysisReport from './AnalysisReport';
@@ -9,11 +9,7 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
-    useEffect(() => {
-        fetchDiffData();
-    }, [sessionId, selectedChanges]);
-
-    const fetchDiffData = async () => {
+    const fetchDiffData = useCallback(async () => {
         try {
             setLoading(true);
 
@@ -58,7 +54,11 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
         } finally {
             setLoading(false);
         }
-    };
+    }, [sessionId, selectedChanges]);
+
+    useEffect(() => {
+        fetchDiffData();
+    }, [fetchDiffData]);
 
     const getChangeTypeIcon = (changeType) => {
         switch (changeType) {


### PR DESCRIPTION
## Summary
- clean up ESLint warning in `TuneDiffViewer` by memoizing `fetchDiffData`
- document verification data expected by end users
- mention documentation in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6864a0d58e9083269926cd4839139270