### PR TITLE
Improve tune metadata display

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The application coordinates several specialized agents:
 
 These agents collaborate through documented APIs and follow strict safety and accessibility requirements.
 
+The UI now includes a **Tune Info Panel** that exposes ROM metadata such as file name, checksum, parser version and table counts for each session.
+
 ## Data Verification
 
 See `docs/data_validation.md` for a checklist of metadata and change details exposed by the platform. For a sample explanation of a detected AFR issue and how a tune change is presented to the user, read `docs/tune_change_example.md`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -451,6 +451,7 @@ async def analyze_package(
                     "analysis_confidence": enhanced_results["quality_metrics"].get(
                         "analysis_confidence", 0
                     ),
+                    "parser_version": enhanced_results.get("metadata", {}).get("parser_version"),
                 }
             )
 
@@ -502,6 +503,20 @@ async def analyze_package(
             "xml_definition_available": definition_path is not None,
             "legacy_fallback_used": legacy_results is not None,
             "total_processing_time": "calculated_in_production",
+        }
+
+        response_data["analysis_metadata"] = analysis_metadata
+        response_data["file_info"] = {
+            "tune": {
+                "filename": session["tune"]["filename"],
+                "hash": session["tune"]["hash"],
+                "size": os.path.getsize(tune_path) if os.path.exists(tune_path) else 0,
+            },
+            "datalog": {
+                "filename": session["datalog"]["filename"],
+                "hash": session["datalog"]["hash"],
+                "size": os.path.getsize(datalog_path) if os.path.exists(datalog_path) else 0,
+            },
         }
 
         return to_python_types(response_data)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import FileUpload from './components/FileUpload';
 import AnalysisViewer from './components/AnalysisViewer';
 import SuggestionsPanel from './components/SuggestionsPanel';
 import TuneDiffViewer from './components/TuneDiffViewer';
+import TuneInfoPanel from './components/TuneInfoPanel';
 import ExportDownloadPanel from './components/ExportDownloadPanel';
 import FeedbackPanel from './components/FeedbackPanel';
 import LoadingSpinner from './components/LoadingSpinner';
@@ -155,6 +156,11 @@ function App() {
 
                 return (
                     <div>
+                        <TuneInfoPanel
+                            romAnalysis={analysisData?.rom_analysis}
+                            metadata={analysisData?.analysis_metadata}
+                            tuneFile={analysisData?.file_info?.tune}
+                        />
                         <AnalysisViewer data={analysisData} />
                         <SuggestionsPanel
                             suggestions={suggestions}
@@ -191,6 +197,7 @@ function App() {
                 return (
                     <TuneDiffViewer
                         sessionId={sessionId}
+                        analysisData={analysisData}
                         selectedChanges={selectedChanges}
                         onApproval={handleDiffApproval}
                     />

--- a/frontend/src/components/TuneDiffViewer.jsx
+++ b/frontend/src/components/TuneDiffViewer.jsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect, useCallback } from 'react';
 import './TuneDiffViewer.css';
 import CarberryTableDiff from './CarberryTableDiff';
 import AnalysisReport from './AnalysisReport';
+import TuneInfoPanel from './TuneInfoPanel';
 
-function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
+function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }) {
     const [diffData, setDiffData] = useState(null);
     const [tableDiff, setTableDiff] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -44,7 +45,8 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
                     changes: detailed,
                     summary,
                     analysisMetadata: data.analysis_metadata,
-                    romCompatibility: data.rom_compatibility
+                    romCompatibility: data.rom_compatibility,
+                    fileInfo: data.file_info
                 });
             } else {
                 setDiffData({ changes: [], summary: {} });
@@ -116,6 +118,11 @@ function TuneDiffViewer({ sessionId, selectedChanges, onApproval }) {
 
     return (
         <div className="tune-diff-viewer">
+            <TuneInfoPanel
+                romAnalysis={analysisData?.rom_analysis || diffData.analysisMetadata?.rom_analysis}
+                metadata={diffData.analysisMetadata}
+                tuneFile={analysisData?.file_info?.tune || diffData.fileInfo?.tune}
+            />
             <div className="diff-header">
                 <h2>Tune Changes Review</h2>
                 <p>Review the proposed changes before applying them to your tune</p>

--- a/frontend/src/components/TuneInfoPanel.css
+++ b/frontend/src/components/TuneInfoPanel.css
@@ -1,0 +1,37 @@
+.tune-info-panel {
+    background: #f8f9fa;
+    border-radius: 10px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.tune-info-panel h3 {
+    color: #333;
+    margin-bottom: 1rem;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.info-item {
+    background: white;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.info-label {
+    display: block;
+    color: #666;
+    font-size: 0.85rem;
+    margin-bottom: 0.25rem;
+}
+
+.info-value {
+    font-weight: bold;
+    font-size: 1rem;
+}

--- a/frontend/src/components/TuneInfoPanel.jsx
+++ b/frontend/src/components/TuneInfoPanel.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './TuneInfoPanel.css';
+
+function TuneInfoPanel({ romAnalysis, metadata, tuneFile }) {
+    if (!romAnalysis) return null;
+
+    const formatItem = (label, value) => (
+        <div className="info-item">
+            <span className="info-label">{label}</span>
+            <span className="info-value">{value !== undefined && value !== null ? String(value) : 'N/A'}</span>
+        </div>
+    );
+
+    return (
+        <div className="tune-info-panel">
+            <h3>Tune & ROM Details</h3>
+            <div className="info-grid">
+                {tuneFile && tuneFile.filename && formatItem('File Name', tuneFile.filename)}
+                {romAnalysis.format && formatItem('Format', romAnalysis.format)}
+                {romAnalysis.rom_size !== undefined && formatItem('ROM Size', `${romAnalysis.rom_size} bytes`)}
+                {romAnalysis.checksum && formatItem('Checksum', romAnalysis.checksum)}
+                {romAnalysis.ecu_id && formatItem('ECU ID', romAnalysis.ecu_id)}
+                {romAnalysis.tables_parsed !== undefined && formatItem('Tables Parsed', romAnalysis.tables_parsed)}
+                {romAnalysis.definition_source && formatItem('Definition', romAnalysis.definition_source)}
+                {metadata && metadata.parser_version && formatItem('Parser Version', metadata.parser_version)}
+            </div>
+        </div>
+    );
+}
+
+export default TuneInfoPanel;


### PR DESCRIPTION
## Summary
- extend analyze_package API to expose tune file info and parser version
- add TuneInfoPanel component with ROM metadata
- show TuneInfoPanel on suggestions and diff pages
- document new panel in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864a841e5048326b9c5849ba2f867c2