### PR TITLE
Improve robustness and UI

### DIFF
--- a/frontend/src/components/AnalysisViewer.jsx
+++ b/frontend/src/components/AnalysisViewer.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import LoadingSpinner from './LoadingSpinner';
 import './AnalysisViewer.css';
 
 function AnalysisViewer({ data }) {
-    if (!data) return null;
+    if (!data) return <LoadingSpinner message="Loading analysis..." />;
 
     // Handle both enhanced and legacy response formats
     const platform = data.platform || 'Unknown';
@@ -159,6 +160,35 @@ function AnalysisViewer({ data }) {
         );
     };
 
+    const renderKeyMetrics = () => {
+        const perf = datalogAnalysis.performance_metrics || datalogAnalysis.performance || {};
+        const temp = summary.temperature_range || {};
+
+        const metrics = [];
+        if (perf.estimated_peak_hp !== undefined) metrics.push({ label: 'Est. Peak HP', value: perf.estimated_peak_hp });
+        if (perf.max_boost !== undefined) metrics.push({ label: 'Max Boost', value: `${perf.max_boost} psi` });
+        if (perf.avg_boost !== undefined) metrics.push({ label: 'Avg Boost', value: `${perf.avg_boost} psi` });
+        if (perf.max_timing !== undefined) metrics.push({ label: 'Max Timing', value: `${perf.max_timing}°` });
+        if (perf.max_duty_cycle !== undefined) metrics.push({ label: 'Max IDC', value: `${perf.max_duty_cycle}%` });
+        if (temp.max !== undefined) metrics.push({ label: 'Max Coolant', value: `${temp.max}°F` });
+
+        if (metrics.length === 0) return null;
+
+        return (
+            <div className="analysis-section">
+                <h3>Key Metrics</h3>
+                <div className="metrics-grid">
+                    {metrics.map((m, idx) => (
+                        <div className="metric-item" key={idx}>
+                            <span className="metric-label">{m.label}</span>
+                            <span className="metric-value">{m.value}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    };
+
     const renderEnhancedMetrics = () => {
         if (!data.quality_metrics) return null;
 
@@ -253,6 +283,7 @@ function AnalysisViewer({ data }) {
                 </div>
 
                 {renderEnhancedMetrics()}
+                {renderKeyMetrics()}
 
                 <div className="analysis-section full-width">
                     <h3>Data Summary</h3>

--- a/frontend/src/components/TuneDiffViewer.jsx
+++ b/frontend/src/components/TuneDiffViewer.jsx
@@ -3,6 +3,7 @@ import './TuneDiffViewer.css';
 import CarberryTableDiff from './CarberryTableDiff';
 import AnalysisReport from './AnalysisReport';
 import TuneInfoPanel from './TuneInfoPanel';
+import LoadingSpinner from './LoadingSpinner';
 
 function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }) {
     const [diffData, setDiffData] = useState(null);
@@ -86,10 +87,7 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
     if (loading) {
         return (
             <div className="tune-diff-viewer">
-                <div className="loading-state">
-                    <div className="spinner"></div>
-                    <p>Generating tune differences...</p>
-                </div>
+                <LoadingSpinner message="Generating tune differences..." />
             </div>
         );
     }
@@ -97,7 +95,7 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
     if (error) {
         return (
             <div className="tune-diff-viewer">
-                <div className="error-state">
+                <div className="error-state" role="alert">
                     <h3>Error Loading Diff</h3>
                     <p>{error}</p>
                 </div>
@@ -108,7 +106,7 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
     if (!diffData || diffData.changes.length === 0) {
         return (
             <div className="tune-diff-viewer">
-                <div className="no-changes">
+                <div className="no-changes" role="alert">
                     <h3>No Changes Selected</h3>
                     <p>Please go back and select some tuning suggestions to review.</p>
                 </div>
@@ -190,6 +188,16 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
                                 {change.summary && (
                                     <p className="change-stats">
                                         Avg {change.summary.avg_change}, Max {change.summary.max_change}
+                                    </p>
+                                )}
+                                {change.predicted_effect && (
+                                    <p className="change-stats">
+                                        {change.predicted_effect.performance && (
+                                            <span>Perf: {change.predicted_effect.performance}; </span>
+                                        )}
+                                        {change.predicted_effect.safety && (
+                                            <span>Safety: {change.predicted_effect.safety}</span>
+                                        )}
                                     </p>
                                 )}
                             </div>


### PR DESCRIPTION
## Summary
- add input validation and logging to TuningEngine
- include predicted effects in generated tune changes
- display loading spinner and key metrics in AnalysisViewer
- show predicted effects and improved error/empty states in TuneDiffViewer

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm install --silent`
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6864ac17d104832686d5a4c56bdeb1a7