### PR TITLE
Enhance analysis UI with context and safety panels

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import AnalysisViewer from './components/AnalysisViewer';
 import SuggestionsPanel from './components/SuggestionsPanel';
 import TuneDiffViewer from './components/TuneDiffViewer';
 import TuneInfoPanel from './components/TuneInfoPanel';
+import SessionContextPanel from './components/SessionContextPanel';
 import ExportDownloadPanel from './components/ExportDownloadPanel';
 import FeedbackPanel from './components/FeedbackPanel';
 import LoadingSpinner from './components/LoadingSpinner';
@@ -156,6 +157,10 @@ function App() {
 
                 return (
                     <div>
+                        <SessionContextPanel
+                            vehicle={analysisData?.vehicle_info}
+                            session={analysisData?.session_info}
+                        />
                         <TuneInfoPanel
                             romAnalysis={analysisData?.rom_analysis}
                             metadata={analysisData?.analysis_metadata}

--- a/frontend/src/components/AnalysisViewer.jsx
+++ b/frontend/src/components/AnalysisViewer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import LoadingSpinner from './LoadingSpinner';
+import DatalogSummaryPanel from './DatalogSummaryPanel';
 import './AnalysisViewer.css';
 
 function AnalysisViewer({ data }) {
@@ -56,6 +57,7 @@ function AnalysisViewer({ data }) {
             summary.issues_found ||
             issues.length ||
             0,
+        time_gaps: summary.time_gaps || datalogAnalysis.time_gap_count || 0,
     };
 
     const renderIssues = () => {
@@ -284,37 +286,16 @@ function AnalysisViewer({ data }) {
 
                 {renderEnhancedMetrics()}
                 {renderKeyMetrics()}
-
-                <div className="analysis-section full-width">
-                    <h3>Data Summary</h3>
-                    <div className="summary-stats">
-                        <div className="stat-item">
-                            <span className="stat-label">Duration</span>
-                            <span className="stat-value">
-                                {datalog_summary.duration ?
-                                    `${datalog_summary.duration.toFixed(1)}s` :
-                                    'Unknown'
-                                }
-                            </span>
-                        </div>
-                        <div className="stat-item">
-                            <span className="stat-label">Data Points</span>
-                            <span className="stat-value">{datalog_summary.total_rows}</span>
-                        </div>
-                        <div className="stat-item">
-                            <span className="stat-label">Parameters</span>
-                            <span className="stat-value">{datalog_summary.total_columns}</span>
-                        </div>
-                        <div className="stat-item">
-                            <span className="stat-label">Issues Found</span>
-                            <span className="stat-value">{datalog_summary.issues_found}</span>
-                        </div>
-                        <div className="stat-item">
-                            <span className="stat-label">Platform</span>
-                            <span className="stat-value">{platform}</span>
-                        </div>
-                    </div>
-                </div>
+                <DatalogSummaryPanel
+                    summary={{
+                        duration: datalog_summary.duration ? `${datalog_summary.duration.toFixed(1)}s` : 'Unknown',
+                        sample_count: datalog_summary.total_rows,
+                        parameter_count: datalog_summary.total_columns,
+                        time_gaps: datalog_summary.time_gaps
+                    }}
+                    quality={data.quality_metrics?.datalog_quality}
+                    scenarios={data.quality_metrics?.required_scenarios}
+                />
             </div>
 
             <div className="debug-section">

--- a/frontend/src/components/DatalogSummaryPanel.css
+++ b/frontend/src/components/DatalogSummaryPanel.css
@@ -1,22 +1,23 @@
-.tune-info-panel {
+.datalog-summary-panel {
     background: #f8f9fa;
     border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 2rem;
 }
 
-.tune-info-panel h3 {
+.datalog-summary-panel h3 {
     color: #333;
     margin-bottom: 1rem;
 }
 
-.info-grid {
+.summary-grid,
+.quality-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 1rem;
 }
 
-.info-item {
+.summary-item, .quality-item {
     background: white;
     padding: 0.75rem 1rem;
     border-radius: 8px;
@@ -24,20 +25,32 @@
     box-shadow: 0 2px 8px rgba(0,0,0,0.05);
 }
 
-.info-label {
+.summary-label, .quality-label {
     display: block;
     color: #666;
     font-size: 0.85rem;
     margin-bottom: 0.25rem;
 }
 
-.info-value {
+.summary-value, .quality-value {
     font-weight: bold;
-    font-size: 1rem;
 }
 
-.info-item .warning {
+.scenario-checks {
+    margin-top: 1rem;
+}
+
+.scenario-checks ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    gap: 1rem;
+}
+
+.scenario-checks li.ok {
+    color: #28a745;
+}
+
+.scenario-checks li.missing {
     color: #dc3545;
-    margin-left: 0.25rem;
-    font-weight: bold;
 }

--- a/frontend/src/components/DatalogSummaryPanel.jsx
+++ b/frontend/src/components/DatalogSummaryPanel.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import './DatalogSummaryPanel.css';
+
+function safe(val, fallback = 'N/A') {
+    return val !== undefined && val !== null ? val : fallback;
+}
+
+export default function DatalogSummaryPanel({ summary = {}, quality = {}, scenarios = {} }) {
+    const scenarioKeys = ['wot', 'idle', 'cruise'];
+    return (
+        <section className="datalog-summary-panel" aria-labelledby="datalog-summary-heading">
+            <h3 id="datalog-summary-heading">Datalog Summary</h3>
+            <div className="summary-grid">
+                <div className="summary-item">
+                    <span className="summary-label">Duration</span>
+                    <span className="summary-value">{safe(summary.duration)}</span>
+                </div>
+                <div className="summary-item">
+                    <span className="summary-label">Samples</span>
+                    <span className="summary-value">{safe(summary.sample_count)}</span>
+                </div>
+                <div className="summary-item">
+                    <span className="summary-label">Parameters</span>
+                    <span className="summary-value">{safe(summary.parameter_count)}</span>
+                </div>
+                <div className="summary-item">
+                    <span className="summary-label">Gaps</span>
+                    <span className="summary-value">{safe(summary.time_gaps)}</span>
+                </div>
+            </div>
+
+            {quality && Object.keys(quality).length > 0 && (
+                <div className="quality-grid" aria-label="Datalog quality metrics">
+                    {Object.entries(quality).map(([k,v]) => (
+                        <div key={k} className="quality-item">
+                            <span className="quality-label">{k}</span>
+                            <span className="quality-value">{safe(v)}</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {scenarios && (
+                <div className="scenario-checks">
+                    <h4>Required Scenarios</h4>
+                    <ul>
+                        {scenarioKeys.map(key => (
+                            <li key={key} className={scenarios[key] ? 'ok' : 'missing'}>
+                                {key.toUpperCase()} {scenarios[key] ? '✔' : '✖'}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/frontend/src/components/SessionContextPanel.css
+++ b/frontend/src/components/SessionContextPanel.css
@@ -1,13 +1,13 @@
-.tune-info-panel {
+.session-context-panel {
     background: #f8f9fa;
     border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 2rem;
 }
 
-.tune-info-panel h3 {
-    color: #333;
+.session-context-panel h3 {
     margin-bottom: 1rem;
+    color: #333;
 }
 
 .info-grid {
@@ -36,8 +36,18 @@
     font-size: 1rem;
 }
 
-.info-item .warning {
-    color: #dc3545;
-    margin-left: 0.25rem;
-    font-weight: bold;
+.mods-list {
+    margin-top: 1rem;
+}
+
+.mods-list ul {
+    list-style: disc;
+    padding-left: 1.5rem;
+}
+
+.vehicle-notes {
+    margin-top: 1rem;
+    background: white;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
 }

--- a/frontend/src/components/SessionContextPanel.jsx
+++ b/frontend/src/components/SessionContextPanel.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import './SessionContextPanel.css';
+
+function safe(value, fallback = 'N/A') {
+    return value !== undefined && value !== null && value !== '' ? value : fallback;
+}
+
+export default function SessionContextPanel({ vehicle = {}, session = {} }) {
+    const mods = Array.isArray(vehicle.mods) ? vehicle.mods : [];
+
+    return (
+        <section className="session-context-panel" aria-labelledby="session-context-heading">
+            <h3 id="session-context-heading">Vehicle & Session Context</h3>
+            <div className="info-grid">
+                {vehicle.vin && (
+                    <div className="info-item">
+                        <span className="info-label">VIN</span>
+                        <span className="info-value">{vehicle.vin}</span>
+                    </div>
+                )}
+                {(vehicle.year || vehicle.make || vehicle.model) && (
+                    <div className="info-item">
+                        <span className="info-label">Vehicle</span>
+                        <span className="info-value">
+                            {[safe(vehicle.year, ''), safe(vehicle.make, ''), safe(vehicle.model, '')].filter(Boolean).join(' ')}
+                        </span>
+                    </div>
+                )}
+                {vehicle.owner && (
+                    <div className="info-item">
+                        <span className="info-label">Owner</span>
+                        <span className="info-value">{vehicle.owner}</span>
+                    </div>
+                )}
+                {vehicle.fuel_type && (
+                    <div className="info-item">
+                        <span className="info-label">Fuel Type</span>
+                        <span className="info-value">{vehicle.fuel_type}</span>
+                    </div>
+                )}
+                {vehicle.region && (
+                    <div className="info-item">
+                        <span className="info-label">Region</span>
+                        <span className="info-value">{vehicle.region}</span>
+                    </div>
+                )}
+                {session.date && (
+                    <div className="info-item">
+                        <span className="info-label">Log Date</span>
+                        <span className="info-value">{new Date(session.date).toLocaleString()}</span>
+                    </div>
+                )}
+            </div>
+
+            {mods.length > 0 && (
+                <div className="mods-list">
+                    <h4>Modifications</h4>
+                    <ul>
+                        {mods.map((m, i) => <li key={i}>{m}</li>)}
+                    </ul>
+                </div>
+            )}
+
+            {vehicle.notes && (
+                <div className="vehicle-notes">
+                    <h4>Notes</h4>
+                    <p>{vehicle.notes}</p>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/frontend/src/components/TuneDiffViewer.css
+++ b/frontend/src/components/TuneDiffViewer.css
@@ -121,6 +121,7 @@
 
 .change-icon {
     font-size: 1.2rem;
+    margin-right: 0.25rem;
 }
 
 .change-parameter {

--- a/frontend/src/components/TuneDiffViewer.jsx
+++ b/frontend/src/components/TuneDiffViewer.jsx
@@ -4,6 +4,7 @@ import CarberryTableDiff from './CarberryTableDiff';
 import AnalysisReport from './AnalysisReport';
 import TuneInfoPanel from './TuneInfoPanel';
 import LoadingSpinner from './LoadingSpinner';
+import WorkflowSafetyPanel from './WorkflowSafetyPanel';
 
 function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }) {
     const [diffData, setDiffData] = useState(null);
@@ -66,10 +67,15 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
     const getChangeTypeIcon = (changeType) => {
         switch (changeType) {
             case 'increased':
+                return '⬆️';
             case 'decreased':
-            case 'modified':
+                return '⬇️';
             case 'added':
+                return '➕';
             case 'removed':
+                return '➖';
+            case 'modified':
+                return '✏️';
             default:
                 return '';
         }
@@ -154,13 +160,14 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
                     <div key={change.id} className="change-item">
                         <div className="change-header">
                             <div className="change-title">
-                                <span className="change-icon">
+                                <span className="change-icon" aria-hidden="true">
                                     {getChangeTypeIcon(change.changeType)}
                                 </span>
                                 <span className="change-parameter">{change.parameter}</span>
                                 <span
                                     className="impact-badge"
                                     style={{ backgroundColor: getImpactColor(change?.impact || change?.priority) }}
+                                    aria-label={`${change?.impact || change?.priority} impact`}
                                 >
                                     {(change?.impact || change?.priority || 'medium').toUpperCase()}
                                 </span>
@@ -196,7 +203,13 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
                                             <span>Perf: {change.predicted_effect.performance}; </span>
                                         )}
                                         {change.predicted_effect.safety && (
-                                            <span>Safety: {change.predicted_effect.safety}</span>
+                                            <span>Safety: {change.predicted_effect.safety}; </span>
+                                        )}
+                                        {change.predicted_effect.forecast && (
+                                            <span>Forecast: {change.predicted_effect.forecast}; </span>
+                                        )}
+                                        {change.confidence && (
+                                            <span>Confidence: {change.confidence}</span>
                                         )}
                                     </p>
                                 )}
@@ -219,6 +232,13 @@ function TuneDiffViewer({ sessionId, analysisData, selectedChanges, onApproval }
                     romCompatibility={diffData.romCompatibility}
                 />
             )}
+
+            <WorkflowSafetyPanel
+                history={diffData.history || []}
+                chat={diffData.chat || []}
+                checklist={diffData.checklist || []}
+                riskStatement={diffData.risk_statement}
+            />
 
             <div className="diff-actions">
                 <div className="safety-notice">

--- a/frontend/src/components/TuneInfoPanel.jsx
+++ b/frontend/src/components/TuneInfoPanel.jsx
@@ -4,10 +4,11 @@ import './TuneInfoPanel.css';
 function TuneInfoPanel({ romAnalysis, metadata, tuneFile }) {
     if (!romAnalysis) return null;
 
-    const formatItem = (label, value) => (
+    const formatItem = (label, value, extra = null) => (
         <div className="info-item">
             <span className="info-label">{label}</span>
             <span className="info-value">{value !== undefined && value !== null ? String(value) : 'N/A'}</span>
+            {extra}
         </div>
     );
 
@@ -16,12 +17,15 @@ function TuneInfoPanel({ romAnalysis, metadata, tuneFile }) {
             <h3>Tune & ROM Details</h3>
             <div className="info-grid">
                 {tuneFile && tuneFile.filename && formatItem('File Name', tuneFile.filename)}
+                {tuneFile && tuneFile.size !== undefined && formatItem('File Size', `${(tuneFile.size/1024).toFixed(1)} KB`)}
                 {romAnalysis.format && formatItem('Format', romAnalysis.format)}
                 {romAnalysis.rom_size !== undefined && formatItem('ROM Size', `${romAnalysis.rom_size} bytes`)}
                 {romAnalysis.checksum && formatItem('Checksum', romAnalysis.checksum)}
                 {romAnalysis.ecu_id && formatItem('ECU ID', romAnalysis.ecu_id)}
-                {romAnalysis.tables_parsed !== undefined && formatItem('Tables Parsed', romAnalysis.tables_parsed)}
-                {romAnalysis.definition_source && formatItem('Definition', romAnalysis.definition_source)}
+                {romAnalysis.tables_parsed !== undefined && formatItem('Tables Parsed', romAnalysis.tables_parsed,
+                    romAnalysis.tables_parsed < 100 ? <span className="warning">!</span> : null)}
+                {romAnalysis.definition_source && formatItem('Definition', romAnalysis.definition_source,
+                    romAnalysis.definition_link && <a href={romAnalysis.definition_link} target="_blank" rel="noopener noreferrer">View</a>)}
                 {metadata && metadata.parser_version && formatItem('Parser Version', metadata.parser_version)}
             </div>
         </div>

--- a/frontend/src/components/WorkflowSafetyPanel.css
+++ b/frontend/src/components/WorkflowSafetyPanel.css
@@ -1,0 +1,20 @@
+.workflow-safety-panel {
+    background: #f8f9fa;
+    border-radius: 10px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+.workflow-safety-panel h3 {
+    color: #333;
+    margin-bottom: 1rem;
+}
+.workflow-safety-panel ul {
+    padding-left: 1.25rem;
+    list-style: disc;
+}
+.risk-statement {
+    margin-top: 1rem;
+    background: #fff3cd;
+    padding: 1rem;
+    border-radius: 8px;
+}

--- a/frontend/src/components/WorkflowSafetyPanel.jsx
+++ b/frontend/src/components/WorkflowSafetyPanel.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import './WorkflowSafetyPanel.css';
+
+export default function WorkflowSafetyPanel({ history = [], chat = [], checklist = [], riskStatement = '', onAcknowledge }) {
+    const [ack, setAck] = useState(false);
+
+    const handleAck = () => {
+        setAck(!ack);
+        if (!ack && onAcknowledge) onAcknowledge();
+    };
+
+    return (
+        <section className="workflow-safety-panel" aria-labelledby="workflow-heading">
+            <h3 id="workflow-heading">Workflow, Communication &amp; Safety</h3>
+
+            {history.length > 0 && (
+                <div className="history-section">
+                    <h4>Session History</h4>
+                    <ul>{history.map((h, i) => <li key={i}>{h}</li>)}</ul>
+                </div>
+            )}
+
+            {chat.length > 0 && (
+                <div className="chat-section">
+                    <h4>Chat Log</h4>
+                    <ul>{chat.map((c, i) => <li key={i}>{c}</li>)}</ul>
+                </div>
+            )}
+
+            {checklist.length > 0 && (
+                <div className="checklist-section">
+                    <h4>Safety Checklist</h4>
+                    <ul>{checklist.map((c, i) => <li key={i}>{c}</li>)}</ul>
+                </div>
+            )}
+
+            {riskStatement && (
+                <div className="risk-statement">
+                    <p>{riskStatement}</p>
+                    <label>
+                        <input type="checkbox" checked={ack} onChange={handleAck} /> I acknowledge the risk
+                    </label>
+                </div>
+            )}
+        </section>
+    );
+}


### PR DESCRIPTION
## Summary
- add new session context and datalog summary panels
- display workflow safety guidance before applying changes
- extend tune info panel with file size, warnings and definition links
- show change icons and forecast details in tune diff viewer
- integrate panels in main app flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b66a92c483269b19ce1bfd5a4fe2