### PR TITLE
Improve analysis response & add tune review component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import './App.css';
 import FileUpload from './components/FileUpload';
 import AnalysisViewer from './components/AnalysisViewer';
-import SuggestionsPanel from './components/SuggestionsPanel';
+import TuneSuggestionsReview from './components/TuneSuggestionsReview';
 import TuneDiffViewer from './components/TuneDiffViewer';
 import TuneInfoPanel from './components/TuneInfoPanel';
 import SessionContextPanel from './components/SessionContextPanel';
@@ -153,8 +153,6 @@ function App() {
 
             case 'suggestions':
                 const suggestions = getSuggestions();
-                console.log('Suggestions found:', suggestions.length); // Debug log
-
                 return (
                     <div>
                         <SessionContextPanel
@@ -167,8 +165,8 @@ function App() {
                             tuneFile={analysisData?.file_info?.tune}
                         />
                         <AnalysisViewer data={analysisData} />
-                        <SuggestionsPanel
-                            suggestions={suggestions}
+                        <TuneSuggestionsReview
+                            analysis={analysisData}
                             onReview={handleSuggestionsReview}
                         />
 

--- a/frontend/src/components/TuneSuggestionsReview.css
+++ b/frontend/src/components/TuneSuggestionsReview.css
@@ -1,0 +1,37 @@
+.tune-suggestions-review {
+    background: white;
+    border-radius: 15px;
+    padding: 2rem;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+    margin-bottom: 2rem;
+}
+
+.analysis-summary {
+    margin-bottom: 1.5rem;
+}
+
+.summary-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+}
+
+.summary-item {
+    background: #f8f9fa;
+    border-radius: 8px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.85rem;
+}
+
+.analysis-error {
+    background: #f8d7da;
+    color: #721c24;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+
+.debug-section {
+    margin-top: 1rem;
+    font-size: 0.8rem;
+}

--- a/frontend/src/components/TuneSuggestionsReview.jsx
+++ b/frontend/src/components/TuneSuggestionsReview.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import SuggestionsPanel from './SuggestionsPanel';
+import './TuneSuggestionsReview.css';
+
+function TuneSuggestionsReview({ analysis, onReview = () => {} }) {
+    if (!analysis) return null;
+
+    const {
+        status = 'unknown',
+        session_id,
+        platform,
+        analysis_type,
+        timestamp,
+        ai_suggestions = [],
+        message,
+        debug
+    } = analysis;
+
+    const formatTime = (ts) => ts ? new Date(ts).toLocaleString() : 'N/A';
+
+    return (
+        <div className="tune-suggestions-review">
+            <div className="analysis-summary">
+                <h3>Tune Analysis Summary</h3>
+                <div className="summary-grid">
+                    <div className="summary-item"><strong>Session:</strong> {session_id}</div>
+                    <div className="summary-item"><strong>Platform:</strong> {platform || 'Unknown'}</div>
+                    <div className="summary-item"><strong>Type:</strong> {analysis_type}</div>
+                    <div className="summary-item"><strong>Status:</strong> {status}</div>
+                    <div className="summary-item"><strong>Time:</strong> {formatTime(timestamp)}</div>
+                </div>
+            </div>
+
+            {status !== 'success' && message && (
+                <div className="analysis-error">
+                    <p>{message}</p>
+                </div>
+            )}
+
+            <SuggestionsPanel suggestions={ai_suggestions} onReview={onReview} />
+
+            {debug && process.env.NODE_ENV === 'development' && (
+                <div className="debug-section">
+                    <details>
+                        <summary>Debug Info</summary>
+                        <pre>{JSON.stringify(debug, null, 2)}</pre>
+                    </details>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default TuneSuggestionsReview;


### PR DESCRIPTION
## Summary
- return structured JSON errors from `/api/analyze_package`
- expose debug info on backend failures
- add TuneSuggestionsReview component to show session info and suggestions
- wire new component into the React app

## Testing
- `pytest -q`
- `CI=true npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c193dbc88326a24b7aad9016794e