### PR TITLE
Add apply changes endpoint and table comparison view

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import FileUpload from './components/FileUpload';
 import AnalysisViewer from './components/AnalysisViewer';
 import TuneSuggestionsReview from './components/TuneSuggestionsReview';
 import TuneDiffViewer from './components/TuneDiffViewer';
+import TuneTableComparison from './components/TuneTableComparison';
 import TuneInfoPanel from './components/TuneInfoPanel';
 import SessionContextPanel from './components/SessionContextPanel';
 import ExportDownloadPanel from './components/ExportDownloadPanel';
@@ -18,6 +19,7 @@ function App() {
     const [selectedChanges, setSelectedChanges] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
+    const [comparisonTables, setComparisonTables] = useState([]);
 
     const handlePackageUpload = (uploadResult) => {
         setSessionId(uploadResult.session_id);
@@ -87,7 +89,8 @@ function App() {
             }
 
             const data = await response.json();
-            setCurrentStep('download');
+            setComparisonTables(data.tables || []);
+            setCurrentStep('comparison');
         } catch (err) {
             setError(err.message);
         } finally {
@@ -105,6 +108,7 @@ function App() {
         setSessionId(null);
         setAnalysisData(null);
         setSelectedChanges([]);
+        setComparisonTables([]);
         setError(null);
     };
 
@@ -209,6 +213,14 @@ function App() {
             case 'apply':
                 return <LoadingSpinner message="Applying changes to your tune..." />;
 
+            case 'comparison':
+                return (
+                    <TuneTableComparison
+                        tables={comparisonTables}
+                        onContinue={() => setCurrentStep('download')}
+                    />
+                );
+
             case 'download':
                 return (
                     <ExportDownloadPanel
@@ -240,6 +252,7 @@ function App() {
                             <div className={`step ${currentStep === 'upload' ? 'active' : ''}`}>Upload</div>
                             <div className={`step ${currentStep === 'suggestions' ? 'active' : ''}`}>Analysis</div>
                             <div className={`step ${currentStep === 'diff' ? 'active' : ''}`}>Review</div>
+                            <div className={`step ${currentStep === 'comparison' ? 'active' : ''}`}>Compare</div>
                             <div className={`step ${currentStep === 'download' ? 'active' : ''}`}>Download</div>
                             <div className={`step ${currentStep === 'feedback' ? 'active' : ''}`}>Feedback</div>
                         </div>

--- a/frontend/src/components/TuneTableComparison.css
+++ b/frontend/src/components/TuneTableComparison.css
@@ -1,0 +1,42 @@
+.table-comparison {
+  margin: 20px 0;
+}
+.table-section {
+  margin-bottom: 30px;
+}
+.tables-wrapper {
+  display: flex;
+  gap: 20px;
+  overflow-x: auto;
+}
+.single-table {
+  flex: 1;
+  min-width: 250px;
+}
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+}
+.tune-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.tune-table th,
+.tune-table td {
+  border: 1px solid #ccc;
+  padding: 4px 6px;
+  text-align: right;
+}
+.tune-table th {
+  background: #f9f9f9;
+}
+.comparison-actions {
+  text-align: center;
+  margin-top: 20px;
+}
+.btn-continue {
+  padding: 8px 16px;
+  font-size: 1rem;
+}

--- a/frontend/src/components/TuneTableComparison.jsx
+++ b/frontend/src/components/TuneTableComparison.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import './TuneTableComparison.css';
+
+function downloadCsv(data, name) {
+  if (!data) return;
+  const csv = data.map(row => row.join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${name}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  window.URL.revokeObjectURL(url);
+}
+
+function renderTable(table) {
+  const { axes = {}, data } = table;
+  const xAxis = axes.x || [];
+  const yAxis = axes.y || [];
+
+  if (!data || data.length === 0) return null;
+
+  return (
+    <table className="tune-table" role="table">
+      <thead>
+        <tr>
+          <th>{'RPM \\ Load'}</th>
+          {yAxis.map((v, i) => (
+            <th key={i}>{v}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {xAxis.map((x, rIdx) => (
+          <tr key={rIdx}>
+            <th>{x}</th>
+            {data[rIdx].map((val, cIdx) => (
+              <td key={cIdx}>{val}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default function TuneTableComparison({ tables = [], onContinue }) {
+  if (!tables.length) return null;
+
+  return (
+    <div className="table-comparison">
+      {tables.map((tbl) => (
+        <div key={tbl.id} className="table-section">
+          <h3>{tbl.name}</h3>
+          <div className="tables-wrapper">
+            <div className="single-table">
+              <div className="table-header">
+                <span>Original</span>
+                <button onClick={() => downloadCsv(tbl.original, `${tbl.id}_original`)}>Download</button>
+              </div>
+              {renderTable({ axes: tbl.axes, data: tbl.original })}
+            </div>
+            <div className="single-table">
+              <div className="table-header">
+                <span>Suggested</span>
+                <button onClick={() => downloadCsv(tbl.modified, `${tbl.id}_modified`)}>Download</button>
+              </div>
+              {renderTable({ axes: tbl.axes, data: tbl.modified })}
+            </div>
+          </div>
+        </div>
+      ))}
+      {onContinue && (
+        <div className="comparison-actions">
+          <button className="btn-continue" onClick={onContinue}>Continue</button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/api/apply_changes` endpoint to return before/after table data
- add React `TuneTableComparison` component with CSV download support
- integrate new comparison step in the app flow

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864c48c4a708326b5654534b7cb171e