### PR TITLE
Fix apply changes endpoint and table comparison

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -85,7 +85,12 @@ function App() {
             });
 
             if (!response.ok) {
-                throw new Error(`Apply changes failed: ${response.statusText}`);
+                let errDetail = response.statusText;
+                try {
+                    const msg = await response.json();
+                    errDetail = msg.detail || msg.message || errDetail;
+                } catch (_) { }
+                throw new Error(`Apply changes failed: ${errDetail}`);
             }
 
             const data = await response.json();
@@ -97,7 +102,6 @@ function App() {
             setLoading(false);
         }
     };
-
     const handleDownloadComplete = () => {
         setCurrentStep('feedback');
     };

--- a/frontend/src/components/TuneTableComparison.css
+++ b/frontend/src/components/TuneTableComparison.css
@@ -40,3 +40,6 @@
   padding: 8px 16px;
   font-size: 1rem;
 }
+.changed-cell {
+  background-color: #fff3cd;
+}

--- a/frontend/src/components/TuneTableComparison.jsx
+++ b/frontend/src/components/TuneTableComparison.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './TuneTableComparison.css';
 
+// Download helper for exporting table data as CSV
 function downloadCsv(data, name) {
   if (!data) return;
   const csv = data.map(row => row.join(',')).join('\n');
@@ -15,7 +16,7 @@ function downloadCsv(data, name) {
   window.URL.revokeObjectURL(url);
 }
 
-function renderTable(table) {
+function renderTable(table, compare = null) {
   const { axes = {}, data } = table;
   const xAxis = axes.x || [];
   const yAxis = axes.y || [];
@@ -36,9 +37,12 @@ function renderTable(table) {
         {xAxis.map((x, rIdx) => (
           <tr key={rIdx}>
             <th>{x}</th>
-            {data[rIdx].map((val, cIdx) => (
-              <td key={cIdx}>{val}</td>
-            ))}
+            {data[rIdx].map((val, cIdx) => {
+              const changed = compare && compare[rIdx] && compare[rIdx][cIdx] !== val;
+              return (
+                <td key={cIdx} className={changed ? 'changed-cell' : ''}>{val}</td>
+              );
+            })}
           </tr>
         ))}
       </tbody>
@@ -67,7 +71,7 @@ export default function TuneTableComparison({ tables = [], onContinue }) {
                 <span>Suggested</span>
                 <button onClick={() => downloadCsv(tbl.modified, `${tbl.id}_modified`)}>Download</button>
               </div>
-              {renderTable({ axes: tbl.axes, data: tbl.modified })}
+              {renderTable({ axes: tbl.axes, data: tbl.modified }, tbl.original)}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- handle errors explicitly in `/api/apply_changes`
- return table metadata and before/after values
- surface API error detail in React App
- highlight changed cells in comparison tables
- allow exporting comparison tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6864c9a990e08326a7457001fa2af423