### PR TITLE
Improve compare workflow

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -63,9 +63,9 @@ function App() {
         setCurrentStep('diff');
     };
 
-    const handleDiffApproval = () => {
+    const handleDiffApproval = async () => {
         setCurrentStep('apply');
-        applyChanges();
+        await applyChanges();
     };
 
     const applyChanges = async () => {
@@ -97,6 +97,7 @@ function App() {
             setComparisonTables(data.tables || []);
             setCurrentStep('comparison');
         } catch (err) {
+            setCurrentStep('diff');
             setError(err.message);
         } finally {
             setLoading(false);

--- a/frontend/src/components/TuneTableComparison.css
+++ b/frontend/src/components/TuneTableComparison.css
@@ -19,6 +19,19 @@
   align-items: center;
   margin-bottom: 5px;
 }
+.download-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+.type-badge {
+  margin-left: 8px;
+  background: #e9ecef;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.8rem;
+}
 .tune-table {
   border-collapse: collapse;
   width: 100%;

--- a/frontend/src/components/TuneTableComparison.jsx
+++ b/frontend/src/components/TuneTableComparison.jsx
@@ -23,11 +23,38 @@ function renderTable(table, compare = null) {
 
   if (!data || data.length === 0) return null;
 
+  // Determine table layout (1D or 2D)
+  const is1D = yAxis.length === 0 || data.length === 1;
+
+  if (is1D) {
+    return (
+      <table className="tune-table" role="table">
+        <thead>
+          <tr>
+            <th>{xAxis.join(' / ') || 'Index'}</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data[0].map((val, cIdx) => {
+            const changed = compare && compare[0] && compare[0][cIdx] !== val;
+            return (
+              <tr key={cIdx}>
+                <th>{xAxis[cIdx] ?? cIdx}</th>
+                <td className={changed ? 'changed-cell' : ''}>{val}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    );
+  }
+
   return (
     <table className="tune-table" role="table">
       <thead>
         <tr>
-          <th>{'RPM \\ Load'}</th>
+          <th>{xAxis.join(' / ') || 'RPM'} \ {yAxis.join(' / ') || 'Load'}</th>
           {yAxis.map((v, i) => (
             <th key={i}>{v}</th>
           ))}
@@ -51,25 +78,71 @@ function renderTable(table, compare = null) {
 }
 
 export default function TuneTableComparison({ tables = [], onContinue }) {
-  if (!tables.length) return null;
+  if (!tables.length) return (
+    <div className="table-comparison empty">No tables to compare.</div>
+  );
+
+  const priorityColor = (p) => {
+    switch ((p || '').toLowerCase()) {
+      case 'critical':
+        return '#dc3545';
+      case 'high':
+        return '#fd7e14';
+      case 'medium':
+        return '#ffc107';
+      case 'low':
+      default:
+        return '#28a745';
+    }
+  };
+
+  const priorityIcon = (p) => {
+    switch ((p || '').toLowerCase()) {
+      case 'critical':
+        return '🚨';
+      case 'high':
+        return '⚠️';
+      case 'medium':
+        return '🔧';
+      default:
+        return '✅';
+    }
+  };
 
   return (
     <div className="table-comparison">
       {tables.map((tbl) => (
         <div key={tbl.id} className="table-section">
-          <h3>{tbl.name}</h3>
+          <h3>
+            {priorityIcon(tbl.priority)} {tbl.name}
+            {tbl.table_type && (
+              <span className="type-badge">{tbl.table_type}</span>
+            )}
+          </h3>
           <div className="tables-wrapper">
             <div className="single-table">
               <div className="table-header">
                 <span>Original</span>
-                <button onClick={() => downloadCsv(tbl.original, `${tbl.id}_original`)}>Download</button>
+                <button
+                  className="download-btn"
+                  title="Download original"
+                  onClick={() => downloadCsv(tbl.original, `${tbl.id}_original`)}
+                >
+                  📥
+                </button>
               </div>
               {renderTable({ axes: tbl.axes, data: tbl.original })}
             </div>
             <div className="single-table">
               <div className="table-header">
-                <span>Suggested</span>
-                <button onClick={() => downloadCsv(tbl.modified, `${tbl.id}_modified`)}>Download</button>
+                <span style={{ color: priorityColor(tbl.priority) }}>Suggested</span>
+                <button
+                  className="download-btn"
+                  title="Download modified"
+                  onClick={() => downloadCsv(tbl.modified, `${tbl.id}_modified`)}
+                >
+                  📥
+                </button>
               </div>
               {renderTable({ axes: tbl.axes, data: tbl.modified }, tbl.original)}
             </div>


### PR DESCRIPTION
## Summary
- include priority and table type when applying changes
- support 1D/2D table comparison with icons and download buttons
- add color indicators and icons for compare tables
- handle errors when applying diff and await navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cdac0d8c8326af1f816508a25829