### PR TITLE
Fix empty compare results handling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -94,8 +94,13 @@ function App() {
             }
 
             const data = await response.json();
-            setComparisonTables(data.tables || []);
-            setCurrentStep('comparison');
+            if (data.tables && data.tables.length > 0) {
+                setComparisonTables(data.tables);
+                setCurrentStep('comparison');
+            } else {
+                setError('No table changes were generated for the selected suggestions.');
+                setCurrentStep('diff');
+            }
         } catch (err) {
             setCurrentStep('diff');
             setError(err.message);

--- a/frontend/src/components/TuneTableComparison.jsx
+++ b/frontend/src/components/TuneTableComparison.jsx
@@ -79,7 +79,9 @@ function renderTable(table, compare = null) {
 
 export default function TuneTableComparison({ tables = [], onContinue }) {
   if (!tables.length) return (
-    <div className="table-comparison empty">No tables to compare.</div>
+    <div className="table-comparison empty" role="alert">
+      No tables to compare. Selected suggestions may not modify any ROM tables.
+    </div>
   );
 
   const priorityColor = (p) => {


### PR DESCRIPTION
## Summary
- handle empty table diff results in `applyChanges`
- clarify message when no tables are available for comparison

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650ad724f48326afeca66230e56f77