### PR TITLE
Fix 3D table parsing for comparison

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -94,8 +94,13 @@ function App() {
             }
 
             const data = await response.json();
-            setComparisonTables(data.tables || []);
-            setCurrentStep('comparison');
+            if (data.tables && data.tables.length > 0) {
+                setComparisonTables(data.tables);
+                setCurrentStep('comparison');
+            } else {
+                setError('No table changes were generated for the selected suggestions.');
+                setCurrentStep('diff');
+            }
         } catch (err) {
             setCurrentStep('diff');
             setError(err.message);

--- a/frontend/src/components/TuneTableComparison.jsx
+++ b/frontend/src/components/TuneTableComparison.jsx
@@ -1,10 +1,55 @@
 import React from 'react';
 import './TuneTableComparison.css';
 
+// Parse legacy [Table2D] or [Table3D] string into axes and matrix
+function parseLegacyTable(str) {
+  if (typeof str !== 'string') return null;
+  const lines = str.trim().split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (!lines.length) return null;
+  const header = lines[0];
+  if (header === '[Table3D]' && lines.length >= 2) {
+    const yAxis = lines[1].split(/\s+/).map(parseFloat);
+    const xAxis = [];
+    const data = [];
+    for (let i = 2; i < lines.length; i += 1) {
+      const parts = lines[i].split(/\s+/).map(parseFloat);
+      if (parts.length === yAxis.length + 1) {
+        xAxis.push(parts[0]);
+        data.push(parts.slice(1));
+      }
+    }
+    return { axes: { x: xAxis, y: yAxis }, data };
+  }
+  if (header === '[Table2D]' && lines.length >= 3) {
+    const xAxis = lines[1].split(/\s+/).map(parseFloat);
+    const dataRow = lines[2].split(/\s+/).map(parseFloat);
+    return { axes: { x: xAxis }, data: [dataRow] };
+  }
+  return null;
+}
+
 // Download helper for exporting table data as CSV
 function downloadCsv(data, name) {
   if (!data) return;
-  const csv = data.map(row => row.join(',')).join('\n');
+
+  let rows = [];
+  if (typeof data === 'string') {
+    const parsed = parseLegacyTable(data);
+    if (parsed) {
+      rows = parsed.data;
+    }
+  } else if (Array.isArray(data[0]) && Array.isArray(data[0][0])) {
+    // 3D table - flatten planes
+    data.forEach((plane, pIdx) => {
+      rows.push([`Layer ${pIdx}`]);
+      plane.forEach((r) => rows.push(r));
+      rows.push([]); // blank line between planes
+    });
+  } else {
+    rows = data;
+  }
+
+  const csv = rows.map((row) => row.join(',')).join('\n');
   const blob = new Blob([csv], { type: 'text/csv' });
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -17,14 +62,47 @@ function downloadCsv(data, name) {
 }
 
 function renderTable(table, compare = null) {
-  const { axes = {}, data } = table;
+  let { axes = {}, data } = table;
+  if (typeof data === 'string') {
+    const parsed = parseLegacyTable(data);
+    if (parsed) {
+      axes = { ...axes, ...parsed.axes };
+      data = parsed.data;
+    } else {
+      return null;
+    }
+  }
   const xAxis = axes.x || [];
   const yAxis = axes.y || [];
+  const zAxis = axes.z || [];
 
   if (!data || data.length === 0) return null;
 
-  // Determine table layout (1D or 2D)
-  const is1D = yAxis.length === 0 || data.length === 1;
+  // Detect table dimensionality
+  if (compare && typeof compare === 'string') {
+    const parsedCompare = parseLegacyTable(compare);
+    if (parsedCompare) {
+      compare = parsedCompare.data;
+    } else {
+      compare = null;
+    }
+  }
+
+  const is3D = Array.isArray(data) && Array.isArray(data[0]) && Array.isArray(data[0][0]);
+  const is1D = Array.isArray(data) && (!Array.isArray(data[0]) || (!is3D && (yAxis.length === 0 || data.length === 1)));
+
+  if (is3D) {
+    return (
+      <div className="table-3d">
+        {data.map((plane, idx) => (
+          <div key={idx} className="table-plane">
+            <div className="plane-label">{zAxis[idx] ?? `Layer ${idx}`}</div>
+            {renderTable({ axes: { x: xAxis, y: yAxis }, data: plane }, compare ? compare[idx] : null)}
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   if (is1D) {
     return (
@@ -79,7 +157,9 @@ function renderTable(table, compare = null) {
 
 export default function TuneTableComparison({ tables = [], onContinue }) {
   if (!tables.length) return (
-    <div className="table-comparison empty">No tables to compare.</div>
+    <div className="table-comparison empty" role="alert">
+      No tables to compare. Selected suggestions may not modify any ROM tables.
+    </div>
   );
 
   const priorityColor = (p) => {


### PR DESCRIPTION
## Summary
- parse `[Table2D]`/`[Table3D]` strings to extract axes and data
- allow TuneTableComparison to render legacy table formats
- include parsed data when downloading CSV exports

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650ad724f48326afeca66230e56f77