### PR TITLE
Improve configuration and logging

### DIFF
--- a/backend/tuning_engine_updated.py
+++ b/backend/tuning_engine_updated.py
@@ -741,6 +741,7 @@ class TuningEngine:
             compatibility["issues"].append("Low table count - definition may be incomplete")
             compatibility["confidence"] = "medium"
         elif isinstance(table_count, (int, float)) and table_count > 500:
+            logger.info("High table count detected: %s", table_count)
             compatibility["recommendations"].append(
                 f"High table count ({table_count}) - verify definition accuracy"
             )


### PR DESCRIPTION
## Summary
- move intake air temperature compensation thresholds to `AIConfig`
- use configurable IAT thresholds when analyzing datalog
- log high table counts in ROM compatibility check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ce342d0c8326aa827a50e164b90a