### PR TITLE
Fix pytest fixture import

### DIFF
--- a/backend/test_real_files.py
+++ b/backend/test_real_files.py
@@ -1,10 +1,10 @@
 import pytest
 from pathlib import Path
+from typing import Dict
 
 from .rom_integration import ROMIntegrationManager
 
 
-@pytest.fixture(scope="session")
 @pytest.fixture(scope="session")
 def sample_paths() -> Dict[str, str]:
     base = Path(__file__).resolve().parents[1] / "test_files"


### PR DESCRIPTION
## Summary
- add missing typing import in real file test
- remove duplicate fixture decorator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e1af7a248326a92ee6869b017d8d