### PR TITLE
Add DynamicMatrixTable and integrate into comparison view

### DIFF
--- a/frontend/src/components/DynamicMatrixTable.css
+++ b/frontend/src/components/DynamicMatrixTable.css
@@ -1,0 +1,45 @@
+/* File: src/frontend/src/components/DynamicMatrixTable.css */
+/* note: styles for the dynamic matrix table component */
+
+.dynamic-matrix-table {
+  overflow-x: auto;
+}
+
+.dynamic-matrix-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.dynamic-matrix-table th,
+.dynamic-matrix-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  text-align: right;
+}
+
+.dynamic-matrix-table tbody tr:nth-child(odd) {
+  background-color: #f9f9f9;
+}
+
+.dynamic-matrix-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f9f9f9;
+  z-index: 2;
+}
+
+.dynamic-matrix-table thead th:first-child {
+  left: 0;
+  z-index: 3;
+}
+
+.dynamic-matrix-table tbody th {
+  position: sticky;
+  left: 0;
+  background: #f9f9f9;
+  z-index: 1;
+}
+
+.dynamic-matrix-table .highlight-cell {
+  background-color: #f8d7da;
+}

--- a/frontend/src/components/DynamicMatrixTable.jsx
+++ b/frontend/src/components/DynamicMatrixTable.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import './DynamicMatrixTable.css';
+
+// note: renders a matrix table based solely on provided axis definitions
+export default function DynamicMatrixTable({
+  xAxis,
+  yAxis,
+  cells,
+  className = '',
+  onDownload,
+}) {
+  if (!xAxis || !yAxis || !Array.isArray(cells)) return null;
+
+  // note: build CSV representation for download callback
+  const buildCsv = () => {
+    const header = [''].concat(xAxis.values).join(',');
+    const rows = yAxis.values.map((y, idx) => {
+      const row = [y].concat(cells[idx]);
+      return row.join(',');
+    });
+    return [header, ...rows].join('\n');
+  };
+
+  const handleDownload = () => {
+    if (onDownload) {
+      onDownload(buildCsv());
+    }
+  };
+
+  const shouldHighlight = (rIdx, cIdx) => {
+    const val = Number(cells[rIdx][cIdx]);
+    if (Number.isNaN(val)) return false;
+
+    let neighbor;
+    if (cIdx > 0) {
+      neighbor = Number(cells[rIdx][cIdx - 1]);
+    } else if (rIdx > 0) {
+      neighbor = Number(cells[rIdx - 1][cIdx]);
+    }
+    if (neighbor === undefined || Number.isNaN(neighbor) || neighbor === 0) return false;
+    return Math.abs(val - neighbor) / Math.abs(neighbor) > 0.1;
+  };
+
+  return (
+    <div className={`dynamic-matrix-table ${className}`}>
+      {onDownload && (
+        <div className="matrix-actions">
+          <button
+            className="download-btn"
+            aria-label="Download table as CSV"
+            onClick={handleDownload}
+          >
+            \uD83D\uDCE5
+          </button>
+        </div>
+      )}
+      <div className="matrix-scroll">
+        <table aria-label="Matrix data table">
+          <thead>
+            <tr>
+              <th></th>
+              {xAxis.values.map((val, i) => (
+                <th key={i} scope="col" title={xAxis.label}>
+                  {val} {xAxis.units}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {yAxis.values.map((yVal, rIdx) => (
+              <tr key={rIdx}>
+                <th scope="row" title={yAxis.label}>
+                  {yVal} {yAxis.units}
+                </th>
+                {xAxis.values.map((x, cIdx) => (
+                  <td
+                    key={cIdx}
+                    className={shouldHighlight(rIdx, cIdx) ? 'highlight-cell' : ''}
+                  >
+                    {cells[rIdx][cIdx]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TuneTableComparison.jsx
+++ b/frontend/src/components/TuneTableComparison.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './TuneTableComparison.css';
+import DynamicMatrixTable from './DynamicMatrixTable';
 
 // Parse legacy [Table2D] or [Table3D] string into axes and matrix
 function parseLegacyTable(str) {
@@ -200,34 +201,19 @@ export default function TuneTableComparison({ tables = [], onContinue }) {
             )}
           </h3>
           <div className="tables-wrapper">
-            <div className="single-table">
-              <div className="table-header">
-                <span>Original</span>
-                <button
-                  className="download-btn"
-                  title="Download original"
-                  aria-label="Download original table"
-                  onClick={() => downloadCsv(tbl.original, `${tbl.id}_original`)}
-                >
-                  📥
-                </button>
-              </div>
-              {renderTable({ axes: tbl.axes, data: tbl.original })}
-            </div>
-            <div className="single-table">
-              <div className="table-header">
-                <span style={{ color: priorityColor(tbl.priority) }}>Suggested</span>
-                <button
-                  className="download-btn"
-                  title="Download modified"
-                  aria-label="Download modified table"
-                  onClick={() => downloadCsv(tbl.modified, `${tbl.id}_modified`)}
-                >
-                  📥
-                </button>
-              </div>
-              {renderTable({ axes: tbl.axes, data: tbl.modified }, tbl.original)}
-            </div>
+            <DynamicMatrixTable
+              xAxis={tbl.original.xAxis || tbl.axes.x}
+              yAxis={tbl.original.yAxis || tbl.axes.y}
+              cells={tbl.original.cells || tbl.original}
+              onDownload={() => downloadCsv(tbl.original, `${tbl.id}_original`)}
+            />
+            <DynamicMatrixTable
+              xAxis={tbl.modified.xAxis || tbl.axes.x}
+              yAxis={tbl.modified.yAxis || tbl.axes.y}
+              cells={tbl.modified.cells || tbl.modified}
+              className="suggested"
+              onDownload={() => downloadCsv(tbl.modified, `${tbl.id}_modified`)}
+            />
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- implement new `DynamicMatrixTable` component with CSV download and cell highlighting
- add corresponding CSS styling
- replace legacy render logic in `TuneTableComparison` with the new component

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686631c7a0a88326adb4f1b766c92a8f